### PR TITLE
Rejuvenate log levels

### DIFF
--- a/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
+++ b/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
@@ -57,7 +57,7 @@ public class MessageCollectorMember implements Member {
   }
 
   private void handleEvent(MessageData data) {
-    LOGGER.info(String.format("%s sees message %s", name, data.getMessage()));
+    LOGGER.finer(String.format("%s sees message %s", name, data.getMessage()));
     messages.add(data.getMessage());
   }
 

--- a/data-bus/src/main/java/com/iluwatar/databus/members/StatusMember.java
+++ b/data-bus/src/main/java/com/iluwatar/databus/members/StatusMember.java
@@ -62,13 +62,13 @@ public class StatusMember implements Member {
 
   private void handleEvent(StartingData data) {
     started = data.getWhen();
-    LOGGER.info(String.format("Receiver #%d sees application started at %s", id, started));
+    LOGGER.severe(String.format("Receiver #%d sees application started at %s", id, started));
   }
 
   private void handleEvent(StoppingData data) {
     stopped = data.getWhen();
-    LOGGER.info(String.format("Receiver #%d sees application stopping at %s", id, stopped));
-    LOGGER.info(String.format("Receiver #%d sending goodbye message", id));
+    LOGGER.severe(String.format("Receiver #%d sees application stopping at %s", id, stopped));
+    LOGGER.severe(String.format("Receiver #%d sending goodbye message", id));
     data.getDataBus().publish(MessageData.of(String.format("Goodbye cruel world from #%d!", id)));
   }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
logger.log(Level.SEVERE,"Service   " + service + " has failed in the "+ from+ "   state.",failure) | SEVERE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | failed(com.google.common.util.concurrent.Service.State,java.lang.Throwable) | 0
logger.log(Level.WARNING,"ignoring   weigher specified without maximumWeight") | WARNING | FINEST | com.google.common.cache.CacheBuilder | checkWeightWithWeigher() | 0
logger.log(SEVERE,String.format(Locale.ROOT,"Caught   an exception in %s.  Shutting   down.",t),e) | SEVERE | FINEST | com.google.common.util.concurrent.UncaughtExceptionHandlers$Exiter | uncaughtException(java.lang.Thread,java.lang.Throwable) | 0
Closeables.logger.log(Level.WARNING,"Suppressing   exception thrown when closing " + closeable,suppressed) | WARNING | FINEST | com.google.common.io.Closer$LoggingSuppressor | suppress(java.io.Closeable,java.lang.Throwable,java.lang.Throwable) | 0
logger.log(Level.FINE,"Service {0}   has terminated. Previous state was: {1}",new Object[]{service,from}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | terminated(com.google.common.util.concurrent.Service.State) | 0
logger.log(Level.SEVERE,message,throwable) | SEVERE | FINEST | com.google.common.util.concurrent.AggregateFuture$RunningState | handleException(java.lang.Throwable) | 0
logger.warning("Cannot read   directory " + directory) | WARNING | FINEST | com.google.common.reflect.ClassPath$DefaultScanner | scanDirectory(java.io.File,java.lang.ClassLoader,java.lang.String,java.util.Set) | 0
logger.log(Level.WARNING,"Error   loading regex compiler, falling back to next option",e) | WARNING | FINEST | com.google.common.base.Platform | logPatternCompilerError(java.util.ServiceConfigurationError) | 0
logger.log(Level.FINE,"Starting   {0}.",service) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | starting() | 0
logger.log(Level.SEVERE,"Detected   potential deadlock",e) | SEVERE | FINEST | com.google.common.util.concurrent.CycleDetectingLockFactory | handlePotentialDeadlock(com.google.common.util.concurrent.CycleDetectingLockFactory.PotentialDeadlockException) | 0
logger.log(Level.FINE,"Started {0}   in {1}.",new Object[]{service,stopwatch}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceManagerState | transitionService(com.google.common.util.concurrent.Service,com.google.common.util.concurrent.Service.State,com.google.common.util.concurrent.Service.State) | 0
logger.log(Level.WARNING,"ServiceManager   configured with no services.  Is your   application configured properly?",new EmptyServiceManagerWarning()) | WARNING | FINEST | com.google.common.util.concurrent.ServiceManager | ServiceManager(java.lang.Iterable) | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Expanded: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.log(Level.INFO,"message",EXCEPTION) | INFO | FINEST | com.google.common.testing.TestLogHandlerTest$ExampleClassUnderTest | foo() | 0
logger.fine("   Sizes: " +   formatFeatureSet(sizesToTest)) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.finer(Platform.format("%s:   excluding because it was explicitly suppressed.",test)) | FINER | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | matches(junit.framework.Test) | 0
logger.fine("Features: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.severe("InterruptenatorTask   did not exit; future tests may be affected") | SEVERE | FINEST | com.google.common.util.concurrent.InterruptionUtil | tearDown() | 0
logger.warning("Unable to delete   file: " + fileThreadLocal.get()) | WARNING | FINEST | com.google.common.io.SourceSinkFactories$FileFactory | tearDown() | 0
logger.log(Level.WARNING,"couldn't   delete file: {0}",new Object[]{file}) | WARNING | FINEST | com.google.common.io.IoTestCase | delete(java.io.File) | 0


##  Manual Change 
This pull request contains one manual change where we changed (please see below) adjusted a test case to reflect our change. This is not part of the output of our tool but simply a necessary change to make the test pass.

```diff
diff --git a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
index 678f1ea4b..9ca57fab7 100644
--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -56,7 +56,7 @@ public class TestLogHandlerTest extends TestCase {
     assertTrue(handler.getStoredLogRecords().isEmpty());
     ExampleClassUnderTest.foo();
     LogRecord record = handler.getStoredLogRecords().get(0);
-    assertEquals(Level.INFO, record.getLevel());
+    assertEquals(Level.FINEST, record.getLevel());
     assertEquals("message", record.getMessage());
     assertSame(EXCEPTION, record.getThrown());
   }
```

## Bug Fix

We found a bug in the same test case where only log messages having level `INFO` or above are tested. Now, all levels are tested. This was also a manual fix.

## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: 74fc49f

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
guava | [0.0, 0.58749896) | FINEST
guava | [0.58749896, 1.1749979) | FINER
guava | [1.1749979, 1.762497) | FINE
guava | [1.762497, 2.3499959) | INFO
guava | [2.3499959, 2.9374948) | WARNING
guava | [2.9374948, 3.524994) | SEVERE
guava-gwt | [0.0, 0.20216666) | FINEST
guava-gwt | [0.20216666, 0.40433332) | FINER
guava-gwt | [0.40433332, 0.60649997) | FINE
guava-gwt | [0.60649997, 0.80866665) | INFO
guava-gwt | [0.80866665, 1.0108333) | WARNING
guava-gwt | [1.0108333, 1.2129999) | SEVERE
guava-testlib | [0.0, 1.8826665) | FINEST
guava-testlib | [1.8826665, 3.765333) | FINER
guava-testlib | [3.765333, 5.6479993) | FINE
guava-testlib | [5.6479993, 7.530666) | INFO
guava-testlib | [7.530666, 9.413332) | WARNING
guava-testlib | [9.413332, 11.295999) | SEVERE
guava-tests | [0.0, 0.9914996) | FINEST
guava-tests | [0.9914996, 1.9829992) | FINER
guava-tests | [1.9829992, 2.9744987) | FINE
guava-tests | [2.9744987, 3.9659984) | INFO
guava-tests | [3.9659984, 4.957498) | WARNING
guava-tests | [4.957498, 5.9489975) | SEVERE

