### PR TITLE
Rejuvenate log levels

### DIFF
--- a/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
+++ b/data-bus/src/main/java/com/iluwatar/databus/members/MessageCollectorMember.java
@@ -57,7 +57,7 @@ public class MessageCollectorMember implements Member {
   }
 
   private void handleEvent(MessageData data) {
-    LOGGER.info(String.format("%s sees message %s", name, data.getMessage()));
+    LOGGER.finer(String.format("%s sees message %s", name, data.getMessage()));
     messages.add(data.getMessage());
   }
 

--- a/data-bus/src/main/java/com/iluwatar/databus/members/StatusMember.java
+++ b/data-bus/src/main/java/com/iluwatar/databus/members/StatusMember.java
@@ -62,13 +62,13 @@ public class StatusMember implements Member {
 
   private void handleEvent(StartingData data) {
     started = data.getWhen();
-    LOGGER.info(String.format("Receiver #%d sees application started at %s", id, started));
+    LOGGER.severe(String.format("Receiver #%d sees application started at %s", id, started));
   }
 
   private void handleEvent(StoppingData data) {
     stopped = data.getWhen();
-    LOGGER.info(String.format("Receiver #%d sees application stopping at %s", id, stopped));
-    LOGGER.info(String.format("Receiver #%d sending goodbye message", id));
+    LOGGER.severe(String.format("Receiver #%d sees application stopping at %s", id, stopped));
+    LOGGER.severe(String.format("Receiver #%d sending goodbye message", id));
     data.getDataBus().publish(MessageData.of(String.format("Goodbye cruel world from #%d!", id)));
   }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
LOGGER.info(String.format("%s   sees message %s",name,data.getMessage())) | INFO | FINER | com.iluwatar.databus.members.MessageCollectorMember | handleEvent(com.iluwatar.databus.data.MessageData) | 0.394
LOGGER.info(String.format("Receiver   #%d sees application started at %s",id,started)) | INFO | SEVERE | com.iluwatar.databus.members.StatusMember | handleEvent(com.iluwatar.databus.data.StartingData) | 1.59
LOGGER.info(String.format("Receiver   #%d sending goodbye message",id)) | INFO | SEVERE | com.iluwatar.databus.members.StatusMember | handleEvent(com.iluwatar.databus.data.StoppingData) | 1.607
LOGGER.info(String.format("Receiver   #%d sees application stopping at %s",id,stopped)) | INFO | SEVERE | com.iluwatar.databus.members.StatusMember | handleEvent(com.iluwatar.databus.data.StoppingData) | 1.607



## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: b6b4602baf5a12d8b76b3f8dd0284bae44230aa9

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
abstract-document | [0.0, 0.436) | FINEST
abstract-document | [0.436, 0.872) | FINER
abstract-document | [0.872, 1.308) | FINE
abstract-document | [1.308, 1.744) | INFO
abstract-document | [1.744, 2.1799998) | WARNING
abstract-document | [2.1799998, 2.616) | SEVERE
abstract-factory | [0.0, 0.89649993) | FINEST
abstract-factory | [0.89649993, 1.7929999) | FINER
abstract-factory | [1.7929999, 2.6894999) | FINE
abstract-factory | [2.6894999, 3.5859997) | INFO
abstract-factory | [3.5859997, 4.4824996) | WARNING
abstract-factory | [4.4824996, 5.3789997) | SEVERE
acyclic-visitor | [0.0, 0.6036666) | FINEST
acyclic-visitor | [0.6036666, 1.2073332) | FINER
acyclic-visitor | [1.2073332, 1.8109999) | FINE
acyclic-visitor | [1.8109999, 2.4146664) | INFO
acyclic-visitor | [2.4146664, 3.018333) | WARNING
acyclic-visitor | [3.018333, 3.6219997) | SEVERE
adapter | [0.0, 0.56633335) | FINEST
adapter | [0.56633335, 1.1326667) | FINER
adapter | [1.1326667, 1.6990001) | FINE
adapter | [1.6990001, 2.2653334) | INFO
adapter | [2.2653334, 2.8316667) | WARNING
adapter | [2.8316667, 3.3980002) | SEVERE
aggregator-service | [0.0, 0.33016667) | FINEST
aggregator-service | [0.33016667, 0.66033334) | FINER
aggregator-service | [0.66033334, 0.9905) | FINE
aggregator-service | [0.9905, 1.3206667) | INFO
aggregator-service | [1.3206667, 1.6508334) | WARNING
aggregator-service | [1.6508334, 1.981) | SEVERE
ambassador | [0.0, 1.1076666) | FINEST
ambassador | [1.1076666, 2.2153332) | FINER
ambassador | [2.2153332, 3.323) | FINE
ambassador | [3.323, 4.4306664) | INFO
ambassador | [4.4306664, 5.538333) | WARNING
ambassador | [5.538333, 6.646) | SEVERE
api-gateway-service | [0.0, 0.11666667) | FINEST
api-gateway-service | [0.11666667, 0.23333333) | FINER
api-gateway-service | [0.23333333, 0.35) | FINE
api-gateway-service | [0.35, 0.46666667) | INFO
api-gateway-service | [0.46666667, 0.5833333) | WARNING
api-gateway-service | [0.5833333, 0.7) | SEVERE
async-method-invocation | [0.0, 0.86249995) | FINEST
async-method-invocation | [0.86249995, 1.7249999) | FINER
async-method-invocation | [1.7249999, 2.5874999) | FINE
async-method-invocation | [2.5874999, 3.4499998) | INFO
async-method-invocation | [3.4499998, 4.3125) | WARNING
async-method-invocation | [4.3125, 5.1749997) | SEVERE
balking | [0.0, 0.54933333) | FINEST
balking | [0.54933333, 1.0986667) | FINER
balking | [1.0986667, 1.648) | FINE
balking | [1.648, 2.1973333) | INFO
balking | [2.1973333, 2.7466667) | WARNING
balking | [2.7466667, 3.296) | SEVERE
bridge | [0.0, 0.78550005) | FINEST
bridge | [0.78550005, 1.5710001) | FINER
bridge | [1.5710001, 2.3565001) | FINE
bridge | [2.3565001, 3.1420002) | INFO
bridge | [3.1420002, 3.9275002) | WARNING
bridge | [3.9275002, 4.7130003) | SEVERE
builder | [0.0, 0.76283336) | FINEST
builder | [0.76283336, 1.5256667) | FINER
builder | [1.5256667, 2.2885) | FINE
builder | [2.2885, 3.0513334) | INFO
builder | [3.0513334, 3.8141668) | WARNING
builder | [3.8141668, 4.577) | SEVERE
business-delegate | [0.0, 0.22766666) | FINEST
business-delegate | [0.22766666, 0.45533332) | FINER
business-delegate | [0.45533332, 0.68299997) | FINE
business-delegate | [0.68299997, 0.91066664) | INFO
business-delegate | [0.91066664, 1.1383333) | WARNING
business-delegate | [1.1383333, 1.3659999) | SEVERE
caching | [0.0, 0.58666664) | FINEST
caching | [0.58666664, 1.1733333) | FINER
caching | [1.1733333, 1.76) | FINE
caching | [1.76, 2.3466666) | INFO
caching | [2.3466666, 2.9333332) | WARNING
caching | [2.9333332, 3.52) | SEVERE
callback | [0.0, 0.45533332) | FINEST
callback | [0.45533332, 0.91066664) | FINER
callback | [0.91066664, 1.3659999) | FINE
callback | [1.3659999, 1.8213333) | INFO
callback | [1.8213333, 2.2766666) | WARNING
callback | [2.2766666, 2.7319999) | SEVERE
chain | [0.0, 0.2305) | FINEST
chain | [0.2305, 0.461) | FINER
chain | [0.461, 0.6915) | FINE
chain | [0.6915, 0.922) | INFO
chain | [0.922, 1.1525) | WARNING
chain | [1.1525, 1.383) | SEVERE
collection-pipeline | [0.0, 0.769) | FINEST
collection-pipeline | [0.769, 1.538) | FINER
collection-pipeline | [1.538, 2.307) | FINE
collection-pipeline | [2.307, 3.076) | INFO
collection-pipeline | [3.076, 3.845) | WARNING
collection-pipeline | [3.845, 4.614) | SEVERE
command | [0.0, 0.45816663) | FINEST
command | [0.45816663, 0.91633326) | FINER
command | [0.91633326, 1.3744999) | FINE
command | [1.3744999, 1.8326665) | INFO
command | [1.8326665, 2.2908332) | WARNING
command | [2.2908332, 2.7489998) | SEVERE
composite | [0.0, 0.5351667) | FINEST
composite | [0.5351667, 1.0703334) | FINER
composite | [1.0703334, 1.6055) | FINE
composite | [1.6055, 2.1406667) | INFO
composite | [2.1406667, 2.6758335) | WARNING
composite | [2.6758335, 3.211) | SEVERE
converter | [0.0, 0.64383334) | FINEST
converter | [0.64383334, 1.2876667) | FINER
converter | [1.2876667, 1.9315) | FINE
converter | [1.9315, 2.5753334) | INFO
converter | [2.5753334, 3.2191668) | WARNING
converter | [3.2191668, 3.863) | SEVERE
cqrs | [0.0, 0.41616663) | FINEST
cqrs | [0.41616663, 0.83233327) | FINER
cqrs | [0.83233327, 1.2484999) | FINE
cqrs | [1.2484999, 1.6646665) | INFO
cqrs | [1.6646665, 2.0808332) | WARNING
cqrs | [2.0808332, 2.4969997) | SEVERE
dao | [0.0, 1.1166667) | FINEST
dao | [1.1166667, 2.2333333) | FINER
dao | [2.2333333, 3.35) | FINE
dao | [3.35, 4.4666667) | INFO
dao | [4.4666667, 5.5833335) | WARNING
dao | [5.5833335, 6.7) | SEVERE
data-bus | [0.0, 0.26783332) | FINEST
data-bus | [0.26783332, 0.53566664) | FINER
data-bus | [0.53566664, 0.80349994) | FINE
data-bus | [0.80349994, 1.0713333) | INFO
data-bus | [1.0713333, 1.3391666) | WARNING
data-bus | [1.3391666, 1.6069999) | SEVERE
data-mapper | [0.0, 1.7198333) | FINEST
data-mapper | [1.7198333, 3.4396665) | FINER
data-mapper | [3.4396665, 5.1594996) | FINE
data-mapper | [5.1594996, 6.879333) | INFO
data-mapper | [6.879333, 8.599166) | WARNING
data-mapper | [8.599166, 10.318999) | SEVERE
data-transfer-object | [0.0, 0.77416664) | FINEST
data-transfer-object | [0.77416664, 1.5483333) | FINER
data-transfer-object | [1.5483333, 2.3225) | FINE
data-transfer-object | [2.3225, 3.0966666) | INFO
data-transfer-object | [3.0966666, 3.8708332) | WARNING
data-transfer-object | [3.8708332, 4.645) | SEVERE
decorator | [0.0, 0.9565) | FINEST
decorator | [0.9565, 1.913) | FINER
decorator | [1.913, 2.8695) | FINE
decorator | [2.8695, 3.826) | INFO
decorator | [3.826, 4.7825) | WARNING
decorator | [4.7825, 5.739) | SEVERE
delegation | [0.0, 0.22766666) | FINEST
delegation | [0.22766666, 0.45533332) | FINER
delegation | [0.45533332, 0.68299997) | FINE
delegation | [0.68299997, 0.91066664) | INFO
delegation | [0.91066664, 1.1383333) | WARNING
delegation | [1.1383333, 1.3659999) | SEVERE
dependency-injection | [0.0, 0.7486667) | FINEST
dependency-injection | [0.7486667, 1.4973334) | FINER
dependency-injection | [1.4973334, 2.246) | FINE
dependency-injection | [2.246, 2.9946668) | INFO
dependency-injection | [2.9946668, 3.7433336) | WARNING
dependency-injection | [3.7433336, 4.492) | SEVERE
dirty-flag | [0.0, 0.52099997) | FINEST
dirty-flag | [0.52099997, 1.0419999) | FINER
dirty-flag | [1.0419999, 1.563) | FINE
dirty-flag | [1.563, 2.0839999) | INFO
dirty-flag | [2.0839999, 2.6049998) | WARNING
dirty-flag | [2.6049998, 3.126) | SEVERE
double-checked-locking | [0.0, 1.0018333) | FINEST
double-checked-locking | [1.0018333, 2.0036666) | FINER
double-checked-locking | [2.0036666, 3.0054998) | FINE
double-checked-locking | [3.0054998, 4.0073333) | INFO
double-checked-locking | [4.0073333, 5.0091667) | WARNING
double-checked-locking | [5.0091667, 6.0109997) | SEVERE
double-dispatch | [0.0, 0.41849998) | FINEST
double-dispatch | [0.41849998, 0.83699995) | FINER
double-dispatch | [0.83699995, 1.2555) | FINE
double-dispatch | [1.2555, 1.6739999) | INFO
double-dispatch | [1.6739999, 2.0925) | WARNING
double-dispatch | [2.0925, 2.511) | SEVERE
eip-aggregator | [0.0, 0.33016667) | FINEST
eip-aggregator | [0.33016667, 0.66033334) | FINER
eip-aggregator | [0.66033334, 0.9905) | FINE
eip-aggregator | [0.9905, 1.3206667) | INFO
eip-aggregator | [1.3206667, 1.6508334) | WARNING
eip-aggregator | [1.6508334, 1.981) | SEVERE
eip-message-channel | [0.0, 0.11666667) | FINEST
eip-message-channel | [0.11666667, 0.23333333) | FINER
eip-message-channel | [0.23333333, 0.35) | FINE
eip-message-channel | [0.35, 0.46666667) | INFO
eip-message-channel | [0.46666667, 0.5833333) | WARNING
eip-message-channel | [0.5833333, 0.7) | SEVERE
eip-publish-subscribe | [0.0, 0.11666667) | FINEST
eip-publish-subscribe | [0.11666667, 0.23333333) | FINER
eip-publish-subscribe | [0.23333333, 0.35) | FINE
eip-publish-subscribe | [0.35, 0.46666667) | INFO
eip-publish-subscribe | [0.46666667, 0.5833333) | WARNING
eip-publish-subscribe | [0.5833333, 0.7) | SEVERE
eip-splitter | [0.0, 0.222) | FINEST
eip-splitter | [0.222, 0.444) | FINER
eip-splitter | [0.444, 0.666) | FINE
eip-splitter | [0.666, 0.888) | INFO
eip-splitter | [0.888, 1.11) | WARNING
eip-splitter | [1.11, 1.332) | SEVERE
eip-wire-tap | [0.0, 0.33866668) | FINEST
eip-wire-tap | [0.33866668, 0.67733335) | FINER
eip-wire-tap | [0.67733335, 1.016) | FINE
eip-wire-tap | [1.016, 1.3546667) | INFO
eip-wire-tap | [1.3546667, 1.6933334) | WARNING
eip-wire-tap | [1.6933334, 2.032) | SEVERE
event-aggregator | [0.0, 0.3245) | FINEST
event-aggregator | [0.3245, 0.649) | FINER
event-aggregator | [0.649, 0.9735) | FINE
event-aggregator | [0.9735, 1.298) | INFO
event-aggregator | [1.298, 1.6225) | WARNING
event-aggregator | [1.6225, 1.947) | SEVERE
event-asynchronous | [0.0, 3.8406665) | FINEST
event-asynchronous | [3.8406665, 7.681333) | FINER
event-asynchronous | [7.681333, 11.521999) | FINE
event-asynchronous | [11.521999, 15.362666) | INFO
event-asynchronous | [15.362666, 19.203333) | WARNING
event-asynchronous | [19.203333, 23.043999) | SEVERE
event-driven-architecture | [0.0, 0.5606667) | FINEST
event-driven-architecture | [0.5606667, 1.1213334) | FINER
event-driven-architecture | [1.1213334, 1.682) | FINE
event-driven-architecture | [1.682, 2.2426667) | INFO
event-driven-architecture | [2.2426667, 2.8033333) | WARNING
event-driven-architecture | [2.8033333, 3.364) | SEVERE
event-queue | [0.0, 1.4576668) | FINEST
event-queue | [1.4576668, 2.9153335) | FINER
event-queue | [2.9153335, 4.373) | FINE
event-queue | [4.373, 5.830667) | INFO
event-queue | [5.830667, 7.288334) | WARNING
event-queue | [7.288334, 8.746) | SEVERE
event-sourcing | [0.0, 3.6725) | FINEST
event-sourcing | [3.6725, 7.345) | FINER
event-sourcing | [7.345, 11.0175) | FINE
event-sourcing | [11.0175, 14.69) | INFO
event-sourcing | [14.69, 18.3625) | WARNING
event-sourcing | [18.3625, 22.035) | SEVERE
execute-around | [0.0, 0.4525) | FINEST
execute-around | [0.4525, 0.905) | FINER
execute-around | [0.905, 1.3575) | FINE
execute-around | [1.3575, 1.81) | INFO
execute-around | [1.81, 2.2624998) | WARNING
execute-around | [2.2624998, 2.715) | SEVERE
extension-objects | [0.0, 0.62116665) | FINEST
extension-objects | [0.62116665, 1.2423333) | FINER
extension-objects | [1.2423333, 1.8634999) | FINE
extension-objects | [1.8634999, 2.4846666) | INFO
extension-objects | [2.4846666, 3.1058333) | WARNING
extension-objects | [3.1058333, 3.7269998) | SEVERE
facade | [0.0, 1.0159999) | FINEST
facade | [1.0159999, 2.0319998) | FINER
facade | [2.0319998, 3.0479999) | FINE
facade | [3.0479999, 4.0639997) | INFO
facade | [4.0639997, 5.0799994) | WARNING
facade | [5.0799994, 6.0959997) | SEVERE
factory-kit | [0.0, 0.3358333) | FINEST
factory-kit | [0.3358333, 0.6716666) | FINER
factory-kit | [0.6716666, 1.0074999) | FINE
factory-kit | [1.0074999, 1.3433332) | INFO
factory-kit | [1.3433332, 1.6791666) | WARNING
factory-kit | [1.6791666, 2.0149999) | SEVERE
factory-method | [0.0, 0.3358333) | FINEST
factory-method | [0.3358333, 0.6716666) | FINER
factory-method | [0.6716666, 1.0074999) | FINE
factory-method | [1.0074999, 1.3433332) | INFO
factory-method | [1.3433332, 1.6791666) | WARNING
factory-method | [1.6791666, 2.0149999) | SEVERE
feature-toggle | [0.0, 0.74300003) | FINEST
feature-toggle | [0.74300003, 1.4860001) | FINER
feature-toggle | [1.4860001, 2.229) | FINE
feature-toggle | [2.229, 2.9720001) | INFO
feature-toggle | [2.9720001, 3.7150002) | WARNING
feature-toggle | [3.7150002, 4.458) | SEVERE
fluentinterface | [0.0, 1.6626667) | FINEST
fluentinterface | [1.6626667, 3.3253334) | FINER
fluentinterface | [3.3253334, 4.988) | FINE
fluentinterface | [4.988, 6.6506667) | INFO
fluentinterface | [6.6506667, 8.3133335) | WARNING
fluentinterface | [8.3133335, 9.976) | SEVERE
flux | [0.0, 0.22766666) | FINEST
flux | [0.22766666, 0.45533332) | FINER
flux | [0.45533332, 0.68299997) | FINE
flux | [0.68299997, 0.91066664) | INFO
flux | [0.91066664, 1.1383333) | WARNING
flux | [1.1383333, 1.3659999) | SEVERE
flyweight | [0.0, 0.2305) | FINEST
flyweight | [0.2305, 0.461) | FINER
flyweight | [0.461, 0.6915) | FINE
flyweight | [0.6915, 0.922) | INFO
flyweight | [0.922, 1.1525) | WARNING
flyweight | [1.1525, 1.383) | SEVERE
front-controller | [0.0, 0.3273333) | FINEST
front-controller | [0.3273333, 0.6546666) | FINER
front-controller | [0.6546666, 0.9819999) | FINE
front-controller | [0.9819999, 1.3093332) | INFO
front-controller | [1.3093332, 1.6366665) | WARNING
front-controller | [1.6366665, 1.9639997) | SEVERE
guarded-suspension | [0.0, 0.4355) | FINEST
guarded-suspension | [0.4355, 0.871) | FINER
guarded-suspension | [0.871, 1.3065) | FINE
guarded-suspension | [1.3065, 1.742) | INFO
guarded-suspension | [1.742, 2.1775) | WARNING
guarded-suspension | [2.1775, 2.613) | SEVERE
half-sync-half-async | [0.0, 0.21350001) | FINEST
half-sync-half-async | [0.21350001, 0.42700002) | FINER
half-sync-half-async | [0.42700002, 0.6405) | FINE
half-sync-half-async | [0.6405, 0.85400003) | INFO
half-sync-half-async | [0.85400003, 1.0675) | WARNING
half-sync-half-async | [1.0675, 1.281) | SEVERE
hexagonal | [0.0, 4.1893334) | FINEST
hexagonal | [4.1893334, 8.378667) | FINER
hexagonal | [8.378667, 12.568001) | FINE
hexagonal | [12.568001, 16.757334) | INFO
hexagonal | [16.757334, 20.946667) | WARNING
hexagonal | [20.946667, 25.136002) | SEVERE
image-microservice | [0.0, 0.2305) | FINEST
image-microservice | [0.2305, 0.461) | FINER
image-microservice | [0.461, 0.6915) | FINE
image-microservice | [0.6915, 0.922) | INFO
image-microservice | [0.922, 1.1525) | WARNING
image-microservice | [1.1525, 1.383) | SEVERE
information-microservice | [0.0, 0.2305) | FINEST
information-microservice | [0.2305, 0.461) | FINER
information-microservice | [0.461, 0.6915) | FINE
information-microservice | [0.6915, 0.922) | INFO
information-microservice | [0.922, 1.1525) | WARNING
information-microservice | [1.1525, 1.383) | SEVERE
intercepting-filter | [0.0, 0.31316665) | FINEST
intercepting-filter | [0.31316665, 0.6263333) | FINER
intercepting-filter | [0.6263333, 0.9395) | FINE
intercepting-filter | [0.9395, 1.2526666) | INFO
intercepting-filter | [1.2526666, 1.5658332) | WARNING
intercepting-filter | [1.5658332, 1.879) | SEVERE
interpreter | [0.0, 0.61499995) | FINEST
interpreter | [0.61499995, 1.2299999) | FINER
interpreter | [1.2299999, 1.8449998) | FINE
interpreter | [1.8449998, 2.4599998) | INFO
interpreter | [2.4599998, 3.0749998) | WARNING
interpreter | [3.0749998, 3.6899996) | SEVERE
inventory-microservice | [0.0, 0.45816663) | FINEST
inventory-microservice | [0.45816663, 0.91633326) | FINER
inventory-microservice | [0.91633326, 1.3744999) | FINE
inventory-microservice | [1.3744999, 1.8326665) | INFO
inventory-microservice | [1.8326665, 2.2908332) | WARNING
inventory-microservice | [2.2908332, 2.7489998) | SEVERE
iterator | [0.0, 0.8856666) | FINEST
iterator | [0.8856666, 1.7713332) | FINER
iterator | [1.7713332, 2.6569998) | FINE
iterator | [2.6569998, 3.5426664) | INFO
iterator | [3.5426664, 4.4283333) | WARNING
iterator | [4.4283333, 5.3139997) | SEVERE
layers | [0.0, 0.31316665) | FINEST
layers | [0.31316665, 0.6263333) | FINER
layers | [0.6263333, 0.9395) | FINE
layers | [0.9395, 1.2526666) | INFO
layers | [1.2526666, 1.5658332) | WARNING
layers | [1.5658332, 1.879) | SEVERE
lazy-loading | [0.0, 0.444) | FINEST
lazy-loading | [0.444, 0.888) | FINER
lazy-loading | [0.888, 1.332) | FINE
lazy-loading | [1.332, 1.776) | INFO
lazy-loading | [1.776, 2.22) | WARNING
lazy-loading | [2.22, 2.664) | SEVERE
marker | [0.0, 0.88516665) | FINEST
marker | [0.88516665, 1.7703333) | FINER
marker | [1.7703333, 2.6555) | FINE
marker | [2.6555, 3.5406666) | INFO
marker | [3.5406666, 4.425833) | WARNING
marker | [4.425833, 5.311) | SEVERE
master-worker-pattern | [0.0, 0.11666667) | FINEST
master-worker-pattern | [0.11666667, 0.23333333) | FINER
master-worker-pattern | [0.23333333, 0.35) | FINE
master-worker-pattern | [0.35, 0.46666667) | INFO
master-worker-pattern | [0.46666667, 0.5833333) | WARNING
master-worker-pattern | [0.5833333, 0.7) | SEVERE
mediator | [0.0, 0.22766666) | FINEST
mediator | [0.22766666, 0.45533332) | FINER
mediator | [0.45533332, 0.68299997) | FINE
mediator | [0.68299997, 0.91066664) | INFO
mediator | [0.91066664, 1.1383333) | WARNING
mediator | [1.1383333, 1.3659999) | SEVERE
memento | [0.0, 0.79966664) | FINEST
memento | [0.79966664, 1.5993333) | FINER
memento | [1.5993333, 2.399) | FINE
memento | [2.399, 3.1986666) | INFO
memento | [3.1986666, 3.9983332) | WARNING
memento | [3.9983332, 4.798) | SEVERE
model-view-controller | [0.0, 0.34149995) | FINEST
model-view-controller | [0.34149995, 0.6829999) | FINER
model-view-controller | [0.6829999, 1.0244999) | FINE
model-view-controller | [1.0244999, 1.3659998) | INFO
model-view-controller | [1.3659998, 1.7074997) | WARNING
model-view-controller | [1.7074997, 2.0489998) | SEVERE
model-view-presenter | [0.0, 0.45533332) | FINEST
model-view-presenter | [0.45533332, 0.91066664) | FINER
model-view-presenter | [0.91066664, 1.3659999) | FINE
model-view-presenter | [1.3659999, 1.8213333) | INFO
model-view-presenter | [1.8213333, 2.2766666) | WARNING
model-view-presenter | [2.2766666, 2.7319999) | SEVERE
module | [0.0, 0.7949999) | FINEST
module | [0.7949999, 1.5899998) | FINER
module | [1.5899998, 2.3849998) | FINE
module | [2.3849998, 3.1799996) | INFO
module | [3.1799996, 3.9749994) | WARNING
module | [3.9749994, 4.7699995) | SEVERE
monad | [0.0, 0.33016667) | FINEST
monad | [0.33016667, 0.66033334) | FINER
monad | [0.66033334, 0.9905) | FINE
monad | [0.9905, 1.3206667) | INFO
monad | [1.3206667, 1.6508334) | WARNING
monad | [1.6508334, 1.981) | SEVERE
monostate | [0.0, 0.444) | FINEST
monostate | [0.444, 0.888) | FINER
monostate | [0.888, 1.332) | FINE
monostate | [1.332, 1.776) | INFO
monostate | [1.776, 2.22) | WARNING
monostate | [2.22, 2.664) | SEVERE
multiton | [0.0, 0.45533332) | FINEST
multiton | [0.45533332, 0.91066664) | FINER
multiton | [0.91066664, 1.3659999) | FINE
multiton | [1.3659999, 1.8213333) | INFO
multiton | [1.8213333, 2.2766666) | WARNING
multiton | [2.2766666, 2.7319999) | SEVERE
mute-idiom | [0.0, 0.80866665) | FINEST
mute-idiom | [0.80866665, 1.6173333) | FINER
mute-idiom | [1.6173333, 2.4259999) | FINE
mute-idiom | [2.4259999, 3.2346666) | INFO
mute-idiom | [3.2346666, 4.043333) | WARNING
mute-idiom | [4.043333, 4.8519998) | SEVERE
mutex | [0.0, 0.538) | FINEST
mutex | [0.538, 1.076) | FINER
mutex | [1.076, 1.614) | FINE
mutex | [1.614, 2.152) | INFO
mutex | [2.152, 2.69) | WARNING
mutex | [2.69, 3.228) | SEVERE
naked-objects-dom | [0.0, 0.6858333) | FINEST
naked-objects-dom | [0.6858333, 1.3716666) | FINER
naked-objects-dom | [1.3716666, 2.0575) | FINE
naked-objects-dom | [2.0575, 2.743333) | INFO
naked-objects-dom | [2.743333, 3.4291663) | WARNING
naked-objects-dom | [3.4291663, 4.115) | SEVERE
naked-objects-integtests | [0.0, 0.6461667) | FINEST
naked-objects-integtests | [0.6461667, 1.2923334) | FINER
naked-objects-integtests | [1.2923334, 1.9385) | FINE
naked-objects-integtests | [1.9385, 2.5846667) | INFO
naked-objects-integtests | [2.5846667, 3.2308335) | WARNING
naked-objects-integtests | [3.2308335, 3.877) | SEVERE
null-object | [0.0, 0.21633333) | FINEST
null-object | [0.21633333, 0.43266666) | FINER
null-object | [0.43266666, 0.649) | FINE
null-object | [0.649, 0.8653333) | INFO
null-object | [0.8653333, 1.0816667) | WARNING
null-object | [1.0816667, 1.298) | SEVERE
object-mother | [0.0, 0.32166663) | FINEST
object-mother | [0.32166663, 0.64333326) | FINER
object-mother | [0.64333326, 0.9649999) | FINE
object-mother | [0.9649999, 1.2866665) | INFO
object-mother | [1.2866665, 1.6083331) | WARNING
object-mother | [1.6083331, 1.9299998) | SEVERE
object-pool | [0.0, 1.3518333) | FINEST
object-pool | [1.3518333, 2.7036667) | FINER
object-pool | [2.7036667, 4.0555) | FINE
object-pool | [4.0555, 5.4073334) | INFO
object-pool | [5.4073334, 6.7591667) | WARNING
object-pool | [6.7591667, 8.111) | SEVERE
observer | [0.0, 0.40766668) | FINEST
observer | [0.40766668, 0.81533337) | FINER
observer | [0.81533337, 1.223) | FINE
observer | [1.223, 1.6306667) | INFO
observer | [1.6306667, 2.0383334) | WARNING
observer | [2.0383334, 2.446) | SEVERE
partial-response | [0.0, 0.9451666) | FINEST
partial-response | [0.9451666, 1.8903332) | FINER
partial-response | [1.8903332, 2.8354998) | FINE
partial-response | [2.8354998, 3.7806664) | INFO
partial-response | [3.7806664, 4.725833) | WARNING
partial-response | [4.725833, 5.6709995) | SEVERE
poison-pill | [0.0, 0.3273333) | FINEST
poison-pill | [0.3273333, 0.6546666) | FINER
poison-pill | [0.6546666, 0.9819999) | FINE
poison-pill | [0.9819999, 1.3093332) | INFO
poison-pill | [1.3093332, 1.6366665) | WARNING
poison-pill | [1.6366665, 1.9639997) | SEVERE
price-microservice | [0.0, 0.2305) | FINEST
price-microservice | [0.2305, 0.461) | FINER
price-microservice | [0.461, 0.6915) | FINE
price-microservice | [0.6915, 0.922) | INFO
price-microservice | [0.922, 1.1525) | WARNING
price-microservice | [1.1525, 1.383) | SEVERE
private-class-data | [0.0, 0.41566667) | FINEST
private-class-data | [0.41566667, 0.83133334) | FINER
private-class-data | [0.83133334, 1.247) | FINE
private-class-data | [1.247, 1.6626667) | INFO
private-class-data | [1.6626667, 2.0783334) | WARNING
private-class-data | [2.0783334, 2.494) | SEVERE
producer-consumer | [0.0, 0.57199997) | FINEST
producer-consumer | [0.57199997, 1.1439999) | FINER
producer-consumer | [1.1439999, 1.7159998) | FINE
producer-consumer | [1.7159998, 2.2879999) | INFO
producer-consumer | [2.2879999, 2.86) | WARNING
producer-consumer | [2.86, 3.4319997) | SEVERE
promise | [0.0, 1.6749998) | FINEST
promise | [1.6749998, 3.3499997) | FINER
promise | [3.3499997, 5.0249996) | FINE
promise | [5.0249996, 6.6999993) | INFO
promise | [6.6999993, 8.374999) | WARNING
promise | [8.374999, 10.049999) | SEVERE
property | [0.0, 0.5635) | FINEST
property | [0.5635, 1.127) | FINER
property | [1.127, 1.6905) | FINE
property | [1.6905, 2.254) | INFO
property | [2.254, 2.8174999) | WARNING
property | [2.8174999, 3.381) | SEVERE
prototype | [0.0, 0.44449997) | FINEST
prototype | [0.44449997, 0.88899994) | FINER
prototype | [0.88899994, 1.3334999) | FINE
prototype | [1.3334999, 1.7779999) | INFO
prototype | [1.7779999, 2.2224998) | WARNING
prototype | [2.2224998, 2.6669998) | SEVERE
proxy | [0.0, 0.28766665) | FINEST
proxy | [0.28766665, 0.5753333) | FINER
proxy | [0.5753333, 0.8629999) | FINE
proxy | [0.8629999, 1.1506666) | INFO
proxy | [1.1506666, 1.4383333) | WARNING
proxy | [1.4383333, 1.7259998) | SEVERE
queue-load-leveling | [0.0, 0.444) | FINEST
queue-load-leveling | [0.444, 0.888) | FINER
queue-load-leveling | [0.888, 1.332) | FINE
queue-load-leveling | [1.332, 1.776) | INFO
queue-load-leveling | [1.776, 2.22) | WARNING
queue-load-leveling | [2.22, 2.664) | SEVERE
reactor | [0.0, 0.48133335) | FINEST
reactor | [0.48133335, 0.9626667) | FINER
reactor | [0.9626667, 1.444) | FINE
reactor | [1.444, 1.9253334) | INFO
reactor | [1.9253334, 2.4066668) | WARNING
reactor | [2.4066668, 2.888) | SEVERE
reader-writer-lock | [0.0, 0.6551667) | FINEST
reader-writer-lock | [0.6551667, 1.3103334) | FINER
reader-writer-lock | [1.3103334, 1.9655001) | FINE
reader-writer-lock | [1.9655001, 2.6206667) | INFO
reader-writer-lock | [2.6206667, 3.2758334) | WARNING
reader-writer-lock | [3.2758334, 3.9310002) | SEVERE
repository | [0.0, 0.9876666) | FINEST
repository | [0.9876666, 1.9753332) | FINER
repository | [1.9753332, 2.9629998) | FINE
repository | [2.9629998, 3.9506664) | INFO
repository | [3.9506664, 4.938333) | WARNING
repository | [4.938333, 5.9259996) | SEVERE
resource-acquisition-is-initialization | [0.0, 0.3245) | FINEST
resource-acquisition-is-initialization | [0.3245, 0.649) | FINER
resource-acquisition-is-initialization | [0.649, 0.9735) | FINE
resource-acquisition-is-initialization | [0.9735, 1.298) | INFO
resource-acquisition-is-initialization | [1.298, 1.6225) | WARNING
resource-acquisition-is-initialization | [1.6225, 1.947) | SEVERE
retry | [0.0, 0.5668333) | FINEST
retry | [0.5668333, 1.1336666) | FINER
retry | [1.1336666, 1.7005) | FINE
retry | [1.7005, 2.2673333) | INFO
retry | [2.2673333, 2.8341665) | WARNING
retry | [2.8341665, 3.401) | SEVERE
sample-application | [0.0, 0.22766666) | FINEST
sample-application | [0.22766666, 0.45533332) | FINER
sample-application | [0.45533332, 0.68299997) | FINE
sample-application | [0.68299997, 0.91066664) | INFO
sample-application | [0.91066664, 1.1383333) | WARNING
sample-application | [1.1383333, 1.3659999) | SEVERE
semaphore | [0.0, 0.54366666) | FINEST
semaphore | [0.54366666, 1.0873333) | FINER
semaphore | [1.0873333, 1.631) | FINE
semaphore | [1.631, 2.1746666) | INFO
semaphore | [2.1746666, 2.7183332) | WARNING
semaphore | [2.7183332, 3.262) | SEVERE
servant | [0.0, 0.3245) | FINEST
servant | [0.3245, 0.649) | FINER
servant | [0.649, 0.9735) | FINE
servant | [0.9735, 1.298) | INFO
servant | [1.298, 1.6225) | WARNING
servant | [1.6225, 1.947) | SEVERE
serverless | [0.0, 0.11666667) | FINEST
serverless | [0.11666667, 0.23333333) | FINER
serverless | [0.23333333, 0.35) | FINE
serverless | [0.35, 0.46666667) | INFO
serverless | [0.46666667, 0.5833333) | WARNING
serverless | [0.5833333, 0.7) | SEVERE
service-layer | [0.0, 1.0561666) | FINEST
service-layer | [1.0561666, 2.1123333) | FINER
service-layer | [2.1123333, 3.1685) | FINE
service-layer | [3.1685, 4.2246666) | INFO
service-layer | [4.2246666, 5.2808332) | WARNING
service-layer | [5.2808332, 6.337) | SEVERE
service-locator | [0.0, 0.33866665) | FINEST
service-locator | [0.33866665, 0.6773333) | FINER
service-locator | [0.6773333, 1.0159999) | FINE
service-locator | [1.0159999, 1.3546666) | INFO
service-locator | [1.3546666, 1.6933333) | WARNING
service-locator | [1.6933333, 2.0319998) | SEVERE
singleton | [0.0, 0.8795) | FINEST
singleton | [0.8795, 1.759) | FINER
singleton | [1.759, 2.6385) | FINE
singleton | [2.6385, 3.518) | INFO
singleton | [3.518, 4.3975) | WARNING
singleton | [4.3975, 5.277) | SEVERE
spatial-partition | [0.0, 0.29616666) | FINEST
spatial-partition | [0.29616666, 0.5923333) | FINER
spatial-partition | [0.5923333, 0.8885) | FINE
spatial-partition | [0.8885, 1.1846666) | INFO
spatial-partition | [1.1846666, 1.4808333) | WARNING
spatial-partition | [1.4808333, 1.777) | SEVERE
specification | [0.0, 0.99616665) | FINEST
specification | [0.99616665, 1.9923333) | FINER
specification | [1.9923333, 2.9884999) | FINE
specification | [2.9884999, 3.9846666) | INFO
specification | [3.9846666, 4.980833) | WARNING
specification | [4.980833, 5.9769998) | SEVERE
state | [0.0, 0.68016666) | FINEST
state | [0.68016666, 1.3603333) | FINER
state | [1.3603333, 2.0405) | FINE
state | [2.0405, 2.7206666) | INFO
state | [2.7206666, 3.4008334) | WARNING
state | [3.4008334, 4.081) | SEVERE
step-builder | [0.0, 0.45816663) | FINEST
step-builder | [0.45816663, 0.91633326) | FINER
step-builder | [0.91633326, 1.3744999) | FINE
step-builder | [1.3744999, 1.8326665) | INFO
step-builder | [1.8326665, 2.2908332) | WARNING
step-builder | [2.2908332, 2.7489998) | SEVERE
strategy | [0.0, 0.86249995) | FINEST
strategy | [0.86249995, 1.7249999) | FINER
strategy | [1.7249999, 2.5874999) | FINE
strategy | [2.5874999, 3.4499998) | INFO
strategy | [3.4499998, 4.3125) | WARNING
strategy | [4.3125, 5.1749997) | SEVERE
template-method | [0.0, 0.22483332) | FINEST
template-method | [0.22483332, 0.44966665) | FINER
template-method | [0.44966665, 0.6745) | FINE
template-method | [0.6745, 0.8993333) | INFO
template-method | [0.8993333, 1.1241666) | WARNING
template-method | [1.1241666, 1.349) | SEVERE
test-automation | [0.0, 0.15116666) | FINEST
test-automation | [0.15116666, 0.30233333) | FINER
test-automation | [0.30233333, 0.45349997) | FINE
test-automation | [0.45349997, 0.60466665) | INFO
test-automation | [0.60466665, 0.7558333) | WARNING
test-automation | [0.7558333, 0.90699995) | SEVERE
thread-pool | [0.0, 0.79966664) | FINEST
thread-pool | [0.79966664, 1.5993333) | FINER
thread-pool | [1.5993333, 2.399) | FINE
thread-pool | [2.399, 3.1986666) | INFO
thread-pool | [3.1986666, 3.9983332) | WARNING
thread-pool | [3.9983332, 4.798) | SEVERE
throttling | [0.0, 2.1973333) | FINEST
throttling | [2.1973333, 4.3946667) | FINER
throttling | [4.3946667, 6.592) | FINE
throttling | [6.592, 8.789333) | INFO
throttling | [8.789333, 10.986667) | WARNING
throttling | [10.986667, 13.184) | SEVERE
tls | [0.0, 0.2763333) | FINEST
tls | [0.2763333, 0.5526666) | FINER
tls | [0.5526666, 0.8289999) | FINE
tls | [0.8289999, 1.1053332) | INFO
tls | [1.1053332, 1.3816665) | WARNING
tls | [1.3816665, 1.6579998) | SEVERE
tolerant-reader | [0.0, 0.8993333) | FINEST
tolerant-reader | [0.8993333, 1.7986666) | FINER
tolerant-reader | [1.7986666, 2.698) | FINE
tolerant-reader | [2.698, 3.5973332) | INFO
tolerant-reader | [3.5973332, 4.4966664) | WARNING
tolerant-reader | [4.4966664, 5.396) | SEVERE
trampoline | [0.0, 1.059) | FINEST
trampoline | [1.059, 2.118) | FINER
trampoline | [2.118, 3.177) | FINE
trampoline | [3.177, 4.236) | INFO
trampoline | [4.236, 5.295) | WARNING
trampoline | [5.295, 6.354) | SEVERE
twin | [0.0, 1.1383333) | FINEST
twin | [1.1383333, 2.2766666) | FINER
twin | [2.2766666, 3.415) | FINE
twin | [3.415, 4.5533333) | INFO
twin | [4.5533333, 5.6916666) | WARNING
twin | [5.6916666, 6.83) | SEVERE
unit-of-work | [0.0, 0.2848333) | FINEST
unit-of-work | [0.2848333, 0.5696666) | FINER
unit-of-work | [0.5696666, 0.85449994) | FINE
unit-of-work | [0.85449994, 1.1393332) | INFO
unit-of-work | [1.1393332, 1.4241666) | WARNING
unit-of-work | [1.4241666, 1.7089999) | SEVERE
value-object | [0.0, 0.33866665) | FINEST
value-object | [0.33866665, 0.6773333) | FINER
value-object | [0.6773333, 1.0159999) | FINE
value-object | [1.0159999, 1.3546666) | INFO
value-object | [1.3546666, 1.6933333) | WARNING
value-object | [1.6933333, 2.0319998) | SEVERE
visitor | [0.0, 0.22483332) | FINEST
visitor | [0.22483332, 0.44966665) | FINER
visitor | [0.44966665, 0.6745) | FINE
visitor | [0.6745, 0.8993333) | INFO
visitor | [0.8993333, 1.1241666) | WARNING
visitor | [1.1241666, 1.349) | SEVERE


